### PR TITLE
Remove unused dart:async import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0+2
+
+- Removed a `dart:async` import that isn't required for \>=Dart 2.1.
+- Require \>=Dart 2.1.
+
 ## 0.2.0+1
 
 - Support Dart 2 stable.

--- a/lib/cli_repl.dart
+++ b/lib/cli_repl.dart
@@ -1,7 +1,5 @@
 library cli_repl;
 
-import 'dart:async';
-
 import 'src/repl_adapter.dart';
 
 class Repl {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cli_repl
 description: A simple library for creating CLI REPLs
-version: 0.2.0+1
+version: 0.2.0+2
 homepage: https://github.com/jathak/cli_repl
 author: Jen Thakar <jen@jenthakar.com>
 
@@ -15,4 +15,4 @@ dev_dependencies:
   test_process: ^1.0.1
 
 environment:
-  sdk: '>=1.20.1 <3.0.0'
+  sdk: '>=2.1 <3.0.0'


### PR DESCRIPTION
Internally I'm trying to enforce these. This assumes a 2.1 SDK where
dart:core exports Future/Stream.

Alternatively, I can land an exception internally for this package.