### PR TITLE
add option to omit white-only entries from repl history

### DIFF
--- a/lib/cli_repl.dart
+++ b/lib/cli_repl.dart
@@ -17,7 +17,8 @@ class Repl {
       {this.prompt: '',
       String continuation,
       StatementValidator validator,
-      this.maxHistory: 50})
+      this.maxHistory: 50,
+      this.logWhitespace: true})
       : continuation = continuation ?? ' ' * prompt.length,
         validator = validator ?? alwaysValid {
     _adapter = new ReplAdapter(this);
@@ -45,6 +46,11 @@ class Repl {
   ///
   /// Defaults to 50.
   int maxHistory;
+
+  /// Should repl history include whitespace-only entries
+  ///
+  /// Defaults to true
+  bool logWhitespace;
 }
 
 /// Returns true if [text] is a complete statement or false otherwise.

--- a/lib/src/repl_adapter/vm.dart
+++ b/lib/src/repl_adapter/vm.dart
@@ -227,7 +227,8 @@ class ReplAdapter {
         String contents = new String.fromCharCodes(buffer);
         setCursor(buffer.length);
         input(char);
-        if (repl.history.isEmpty || contents != repl.history.first) {
+        if ((repl.history.isEmpty || contents != repl.history.first)
+          && (contents.trim().isNotEmpty || repl.logWhitespace)) {
           repl.history.insert(0, contents);
         }
         while (repl.history.length > repl.maxHistory) {


### PR DESCRIPTION
(edited first PR attempt to fix issue with branches)

I'm hoping to use this library for the repl of my language, Pointless. I wonder whether you'd consider pulling a small change I've made. My fork adds boolean param to the repl constructor that controls whether whitespace-only repl inputs are added to the repl history (set to true by default for backwards-compatibility). It's a nice option to have since most PL repls leave out blank lines.

Thanks for making this library btw -- it's just what I've been looking for!