### PR TITLE
Remove unnecessary dart:async imports

### DIFF
--- a/lib/src/repl_adapter/interface.dart
+++ b/lib/src/repl_adapter/interface.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import '../../cli_repl.dart';
 
 class ReplAdapter {

--- a/lib/src/repl_adapter/vm.dart
+++ b/lib/src/repl_adapter/vm.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 
 import 'package:async/async.dart';


### PR DESCRIPTION
As of Dart 2.1, Future/Stream have been exported from dart:core.