### PR TITLE
Change default values to use equal not colon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.3
+
+- Code cleanup to change how some parameters are initialized.
+
 ## 0.2.2
 
 - Avoid triggering https://github.com/dart-lang/sdk/issue/34775.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,3 @@
-analyzer:
-  errors:
-    missing_js_lib_annotation: ignore
-
 # Lint rules and documentation, see http://dart-lang.github.io/linter/lints
 linter:
   rules:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,3 +12,5 @@ linter:
     - test_types_in_equals
     - unrelated_type_equality_checks
     - valid_regexps
+    - prefer_equal_for_default_values
+

--- a/lib/cli_repl.dart
+++ b/lib/cli_repl.dart
@@ -16,10 +16,10 @@ class Repl {
   StatementValidator validator;
 
   Repl(
-      {this.prompt: '',
+      {this.prompt = '',
       String? continuation,
       StatementValidator? validator,
-      this.maxHistory: 50})
+      this.maxHistory = 50})
       : continuation = continuation ?? ' ' * prompt.length,
         validator = validator ?? alwaysValid {
     _adapter = new ReplAdapter(this);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: cli_repl
 description: A simple library for creating CLI REPLs
 version: 0.2.2
 homepage: https://github.com/jathak/cli_repl
-author: Jen Thakar <jen@jenthakar.com>
+# author: Jen Thakar <jen@jenthakar.com>
 
 dependencies:
   async: ^2.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cli_repl
 description: A simple library for creating CLI REPLs
-version: 0.2.2
+version: 0.2.3
 homepage: https://github.com/jathak/cli_repl
 # author: Jen Thakar <jen@jenthakar.com>
 


### PR DESCRIPTION
For historical reasons, Dart named optional parameters can specify their default value using either : or =. The Dart team is considering deprecating support for using :, so this migrates to using =.

Context: https://github.com/dart-lang/language/issues/2357